### PR TITLE
Resetting the object called `handlers` of `logger` to a clean state

### DIFF
--- a/tests/plugins/log/test_log_plugin.py
+++ b/tests/plugins/log/test_log_plugin.py
@@ -30,6 +30,7 @@ def test_log_plugin_with_initialization():
     assert log['logLevel'] == "INFO"
     assert log['logLevelCode'] == 2
     del execution_context.logs[:]
+    logger.removeHandler(log_handler)
 
 
 def test_log_plugin_with_config_file():

--- a/tests/plugins/log/test_log_plugin.py
+++ b/tests/plugins/log/test_log_plugin.py
@@ -22,15 +22,17 @@ def test_log_plugin_with_initialization():
     execution_context.capture_log = True
     logger.info("This is an info log")
 
-    assert len(execution_context.logs) == 1
-    log = execution_context.logs[0]
+    try:
+        assert len(execution_context.logs) == 1
+        log = execution_context.logs[0]
 
-    assert log['logMessage'] == "This is an info log"
-    assert log['logContextName'] == 'test_handler'
-    assert log['logLevel'] == "INFO"
-    assert log['logLevelCode'] == 2
-    del execution_context.logs[:]
-    logger.removeHandler(log_handler)
+        assert log['logMessage'] == "This is an info log"
+        assert log['logContextName'] == 'test_handler'
+        assert log['logLevel'] == "INFO"
+        assert log['logLevelCode'] == 2
+    finally:
+        del execution_context.logs[:]
+        logger.removeHandler(log_handler)
 
 
 def test_log_plugin_with_config_file():


### PR DESCRIPTION
The PR aims to improve the reliability of the test `test_log_plugin_with_initialization` in `test_log_plugin.py` by resetting the object called `handlers` of `logger` to a clean state by calling the method `removeHandler`.

The test can fail in the following way if `handlers` is not in a clean state:
```
>       assert len(execution_context.logs) == 1
E       AssertionError: assert 2 == 1
E        +  where 2 = len([{'id': 'bdda97a1-8ce1-4a90-9715-b2e54b30a15a', 'logContextName': 'test_handler', 'logLevel': 'INFO', 'logLevelCode': ... '0f4255e7-2684-4a23-b90b-d1c40c5def1a', 'logContextName': 'test_handler', 'logLevel': 'INFO', 'logLevelCode': 2, ...}])
E        +    where [{'id': 'bdda97a1-8ce1-4a90-9715-b2e54b30a15a', 'logContextName': 'test_handler', 'logLevel': 'INFO', 'logLevelCode': ... '0f4255e7-2684-4a23-b90b-d1c40c5def1a', 'logContextName': 'test_handler', 'logLevel': 'INFO', 'logLevelCode': 2, ...}] = <thundra.context.execution_context.ExecutionContext object at 0x7ff2acf00850>.logs
```